### PR TITLE
changed return type from option to result to display internal error

### DIFF
--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -7,19 +7,20 @@ pub fn decode(bytes: Vec<u8>) -> Result<String, String> {
 
     match decoder.read_to_string(&mut xml) {
         Ok(_) => Ok(xml),
-        Err(error) => Err(error.to_string())
+        Err(error) => Err(error.to_string()),
     }
 }
 
-pub fn encode(content: &str) -> Result<String, String> {
-    use flate2::read::GzDecoder;
+pub fn encode(content: &str) -> Result<Vec<u8>, String> {
+    use flate2::read::GzEncoder;
+    use flate2::Compression;
     use std::io::Read;
 
-    let mut decoder = GzDecoder::new(&bytes[..]);
-    let mut xml = String::new();
+    let mut encoder = GzEncoder::new(content.as_bytes(), Compression::best());
+    let mut bytes = Vec::new();
 
-    match decoder.read_to_string(&mut xml) {
-        Ok(_) => Ok(xml),
+    match encoder.read_to_end(&mut bytes) {
+        Ok(_) => Ok(bytes),
         Err(error) => Err(error.to_string()),
     }
 }

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -1,4 +1,4 @@
-pub fn decode(bytes: Vec<u8>) -> Option<String> {
+pub fn decode(bytes: Vec<u8>) -> Result<String, String> {
     use flate2::read::GzDecoder;
     use std::io::Read;
 
@@ -6,21 +6,20 @@ pub fn decode(bytes: Vec<u8>) -> Option<String> {
     let mut xml = String::new();
 
     match decoder.read_to_string(&mut xml) {
-        Ok(_) => Some(xml),
-        Err(_) => None,
+        Ok(_) => Ok(xml),
+        Err(error) => Err(error.to_string())
     }
 }
 
-pub fn encode(content: &str) -> Option<Vec<u8>> {
-    use flate2::read::GzEncoder;
-    use flate2::Compression;
+pub fn encode(content: &str) -> Result<String, String> {
+    use flate2::read::GzDecoder;
     use std::io::Read;
 
-    let mut encoder = GzEncoder::new(content.as_bytes(), Compression::best());
-    let mut bytes = Vec::new();
+    let mut decoder = GzDecoder::new(&bytes[..]);
+    let mut xml = String::new();
 
-    match encoder.read_to_end(&mut bytes) {
-        Ok(_) => Some(bytes),
-        Err(_) => None,
+    match decoder.read_to_string(&mut xml) {
+        Ok(_) => Ok(xml),
+        Err(error) => Err(error.to_string()),
     }
 }


### PR DESCRIPTION
Ist relevant um hier sinnvollere Fehlermeldungen zu erhalten. 
https://github.com/demvsystems/vertragsservice-upload-lambda/pull/146

Ich weiß noch nicht, ob das decode noch woanders verwendet wird. Auch nicht wo das encode verwendet wird. 
Laut gesundem menschenverstand würde ich sagen, dass es ja mindestens ein weiteres Projekt bei uns geben muss das decode und encode verwendet, da sonst ja die Methoden in dieser Lib eher overhead sind. Müssen wir also suchen.